### PR TITLE
nvidia-container-toolkit-v1.17.6_docker-v28.0.0-rc.1 v0.9.0: install …

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ root@localhost:~# docker version
 | --- | --- | --- | --- |
 | [nvidia-container-toolkit-v1.17.8](./nvidia-container-toolkit/v1.17.8/) | v0.3.0 | |  |
 | [nvidia-container-toolkit-v1.17.7](./nvidia-container-toolkit/v1.17.7/) | v0.3.0 | |  |
-| [nvidia-container-toolkit-v1.17.6_docker-v28.0.0-rc.1](./nvidia-container-toolkit/v1.17.6_docker-v28.0.0-rc.1/) | v0.3.0 | |  |
+| [nvidia-container-toolkit-v1.17.6_docker-v28.0.0-rc.1](./nvidia-container-toolkit/v1.17.6_docker-v28.0.0-rc.1/) | v0.9.0 | |  |
 | [nvidia-container-toolkit-v1.17.6_docker-v27.5.1](./nvidia-container-toolkit/v1.17.6_docker-v27.5.1/) | v0.9.0 | |  |
 | [nvidia-container-toolkit-v1.17.6-debug](./nvidia-container-toolkit/v1.17.6-debug/) | v0.3.0 | |  |
 | [nvidia-container-toolkit-v1.17.6](./nvidia-container-toolkit/v1.17.6/) | v0.9.0 | |  |

--- a/nvidia-container-toolkit/v1.17.6_docker-v28.0.0-rc.1/.env
+++ b/nvidia-container-toolkit/v1.17.6_docker-v28.0.0-rc.1/.env
@@ -1,3 +1,3 @@
-VERSION=v0.3.0
+VERSION=v0.9.0
 IMAGE=nvidia-container-toolkit-v1.17.6_docker-v28.0.0-rc.1
 COMPOSE_PROJECT_NAME=nvidia-container-toolkit-1-17-6-docker-28-0-0-rc-1

--- a/nvidia-container-toolkit/v1.17.6_docker-v28.0.0-rc.1/Dockerfile
+++ b/nvidia-container-toolkit/v1.17.6_docker-v28.0.0-rc.1/Dockerfile
@@ -1,35 +1,50 @@
 ARG HOSTNAME=nvidia-container-toolkit-1-17-6-docker-28-0-0-rc-1
 ARG VERSION_NCT=1.17.6
-ARG VERSION_NCT_PKG=1.17.6-1
-ARG VERSION_FAKE_NVIDIA=0.7.1
+ARG VERSION_NCT_PKG=${VERSION_NCT}-1
+ARG VERSION_FAKE_NVIDIA=0.7.2
 ARG VERSION_DOCKER=28.0.0-rc.1
-ARG VERSION_KERNEL=6.8.0-64-generic
+ARG VERSION_KERNEL=6.8.0-71-generic
 ARG VERSION_NVIDIA_DRIVER=575.57.08
-ARG VERSION_CUDA=12.9
-ARG IMAGE_CUDA=nvidia/cuda:12.9.1-base-ubuntu24.04
 ARG BASE_IMAGE=ssst0n3/docker_archive:ctr_docker-v${VERSION_DOCKER}
 ARG VERSION_IMAGE=0.1.0
 ARG URL_ARTIFACT_FAKE=https://github.com/ssst0n3/fake-nvidia/archive/refs/tags/v${VERSION_FAKE_NVIDIA}.tar.gz
+ARG URL_ARTIFACT_DRIVER=https://us.download.nvidia.com/tesla/${VERSION_NVIDIA_DRIVER}/NVIDIA-Linux-x86_64-${VERSION_NVIDIA_DRIVER}.run
 
-FROM ${IMAGE_CUDA} AS cuda
-FROM ${BASE_IMAGE}_v${VERSION_IMAGE} AS builder
-ARG VERSION_KERNEL
-RUN apt update && \
-    apt install -y build-essential linux-headers-${VERSION_KERNEL}
+# https://gitlab.com/nvidia/container-images/driver/-/blob/master/ubuntu18.04/Dockerfile#L48
+FROM ${BASE_IMAGE}_v${VERSION_IMAGE} AS driver
+ARG URL_ARTIFACT_DRIVER
+ADD --chmod=755 ${URL_ARTIFACT_DRIVER} /tmp/nvidia-driver.run
+RUN dpkg --add-architecture i386 && \
+    apt update && \
+    apt install -y \
+        # Fix: Unable to find the module utility modprobe
+        kmod \
+        # Fix: Unable to find a suitable destination to install 32-bit compatibility libraries
+        libc6:i386 \
+        # Fix: WARNING: Unable to determine the path to install the libglvnd EGL vendor library config files. 
+        # Check that you have pkg-config and the libglvnd development libraries installed, 
+        # or specify a path with --glvnd-egl-config-path.
+        pkg-config \
+        # Fix: WARNING: This NVIDIA driver package includes Vulkan components, but no Vulkan ICD loader was detected on this system. 
+        # The NVIDIA Vulkan ICD will not function without the loader. Most distributions package the Vulkan loader; 
+        # try installing the "vulkan-loader", "vulkan-icd-loader", or "libvulkan1" package.
+        libglvnd-dev 
+RUN /tmp/nvidia-driver.run --silent \
+    --no-kernel-module \
+    --install-compat32-libs
 
-FROM builder AS fake-nvidia
+FROM driver AS fake-nvidia
 ARG VERSION_FAKE_NVIDIA
 ARG VERSION_KERNEL
 ARG VERSION_NVIDIA_DRIVER
-ARG VERSION_CUDA
 ARG URL_ARTIFACT_FAKE
 ADD ${URL_ARTIFACT_FAKE} /tmp/fake-nvidia.tar.gz
+RUN apt update && apt install -y build-essential linux-headers-${VERSION_KERNEL}
 RUN tar -xzf /tmp/fake-nvidia.tar.gz -C /tmp && \
     mv /tmp/fake-nvidia-${VERSION_FAKE_NVIDIA} /usr/local/fake-nvidia && \
     rm -rf /tmp/fake-nvidia.tar.gz && \
     cd /usr/local/fake-nvidia && \
     KERNEL_RELEASE=${VERSION_KERNEL} NVIDIA_DRIVER_VERSION=${VERSION_NVIDIA_DRIVER} make install
-COPY --from=cuda /usr/local/cuda-${VERSION_CUDA}/compat/libcuda.so.${VERSION_NVIDIA_DRIVER} /usr/local/lib/libcuda.so.${VERSION_NVIDIA_DRIVER}
 
 FROM fake-nvidia AS nvidia-container-toolkit
 ARG VERSION_NCT_PKG

--- a/nvidia-container-toolkit/v1.17.6_docker-v28.0.0-rc.1/README.md
+++ b/nvidia-container-toolkit/v1.17.6_docker-v28.0.0-rc.1/README.md
@@ -1,12 +1,14 @@
 # nvidia-container-toolkit v1.17.6 with docker v28.0.0-rc.1
 
 * dqd:
-  * ssst0n3/docker_archive:nvidia-container-toolkit-v1.17.6_docker-v28.0.0-rc.1 -> ssst0n3/docker_archive:nvidia-container-toolkit-v1.17.6_docker-v28.0.0-rc.1_v0.3.0
+  * ssst0n3/docker_archive:nvidia-container-toolkit-v1.17.6_docker-v28.0.0-rc.1 -> ssst0n3/docker_archive:nvidia-container-toolkit-v1.17.6_docker-v28.0.0-rc.1_v0.9.0
+  * ssst0n3/docker_archive:nvidia-container-toolkit-v1.17.6_docker-v28.0.0-rc.1_v0.9.0
   * ssst0n3/docker_archive:nvidia-container-toolkit-v1.17.6_docker-v28.0.0-rc.1_v0.3.0
   * ssst0n3/docker_archive:nvidia-container-toolkit-v1.17.6_docker-v28.0.0-rc.1_v0.2.0
   * ssst0n3/docker_archive:nvidia-container-toolkit-v1.17.6_docker-v28.0.0-rc.1_v0.1.0
 * ctr:
-  * ssst0n3/docker_archive:ctr_nvidia-container-toolkit-v1.17.6_docker-v28.0.0-rc.1 -> ssst0n3/docker_archive:ctr_nvidia-container-toolkit-v1.17.6_docker-v28.0.0-rc.1_v0.3.0
+  * ssst0n3/docker_archive:ctr_nvidia-container-toolkit-v1.17.6_docker-v28.0.0-rc.1 -> ssst0n3/docker_archive:ctr_nvidia-container-toolkit-v1.17.6_docker-v28.0.0-rc.1_v0.9.0
+  * ssst0n3/docker_archive:ctr_nvidia-container-toolkit-v1.17.6_docker-v28.0.0-rc.1_v0.9.0: install real nvidia driver without kernel module; install i386 libs; bump fake-nvidia to v0.7.2
   * ssst0n3/docker_archive:ctr_nvidia-container-toolkit-v1.17.6_docker-v28.0.0-rc.1_v0.3.0: bump fake-nvidia to v0.7.1
   * ssst0n3/docker_archive:ctr_nvidia-container-toolkit-v1.17.6_docker-v28.0.0-rc.1_v0.2.0: CDI compatible
   * ssst0n3/docker_archive:ctr_nvidia-container-toolkit-v1.17.6_docker-v28.0.0-rc.1_v0.1.0
@@ -23,8 +25,8 @@ $ ./ssh
 
 ```shell
 root@nvidia-container-toolkit-1-17-6-docker-28-0-0-rc-1:~# docker run -tid --runtime=nvidia --gpus=all busybox
-eb06ca5c068daec9cf33589f1b3a06c9cc9033702d9821905ce888f0901c3ced
-root@nvidia-container-toolkit-1-17-6-docker-28-0-0-rc-1:~# cat /run/containerd/io.containerd.runtime.v2.task/moby/eb06ca5c068daec9cf33589f1b3a06c9cc9033702d9821905ce888f0901c3ced/config.json | jq .hooks
+71d10c7fab0c28cc0cf119720f3010024b00c34a3bc2727c6595bbb24a554115
+root@nvidia-container-toolkit-1-17-6-docker-28-0-0-rc-1:~# cat /run/containerd/io.containerd.runtime.v2.task/moby/71d10c7fab0c28cc0cf119720f3010024b00c34a3bc2727c6595bbb24a554115/config.json | jq .hooks
 {
   "prestart": [
     {
@@ -64,7 +66,7 @@ root@nvidia-container-toolkit-1-17-6-docker-28-0-0-rc-1:~# cat /run/containerd/i
 
 ```shell
 root@nvidia-container-toolkit-1-17-6-docker-28-0-0-rc-1:~# nvidia-ctk cdi generate --output=/etc/cdi/nvidia.yaml
-INFO[0000] Using /usr/local/lib/libnvidia-ml.so.1       
+INFO[0000] Using /usr/lib/x86_64-linux-gnu/libnvidia-ml.so.575.57.08 
 INFO[0000] Auto-detected mode as 'nvml'                 
 INFO[0000] Selecting /dev/nvidia0 as /dev/nvidia0       
 WARN[0000] Failed to evaluate symlink /dev/dri/by-path/pci--card; ignoring 
@@ -79,55 +81,74 @@ INFO[0000] Selecting /dev/nvidia3 as /dev/nvidia3
 WARN[0000] Failed to evaluate symlink /dev/dri/by-path/pci--card; ignoring 
 WARN[0000] Failed to evaluate symlink /dev/dri/by-path/pci--render; ignoring 
 INFO[0000] Using driver version 575.57.08               
-WARN[0000] Could not locate /dev/nvidia-modeset: pattern /dev/nvidia-modeset not found 
+INFO[0000] Selecting /dev/nvidia-modeset as /dev/nvidia-modeset 
 WARN[0000] Could not locate /dev/nvidia-uvm-tools: pattern /dev/nvidia-uvm-tools not found 
 WARN[0000] Could not locate /dev/nvidia-uvm: pattern /dev/nvidia-uvm not found 
 INFO[0000] Selecting /dev/nvidiactl as /dev/nvidiactl   
-WARN[0000] Could not locate libnvidia-egl-gbm.so.*.*: pattern libnvidia-egl-gbm.so.*.* not found
-libnvidia-egl-gbm.so.*.*: not found 
-WARN[0000] Could not locate libnvidia-egl-wayland.so.*.*: pattern libnvidia-egl-wayland.so.*.* not found
-libnvidia-egl-wayland.so.*.*: not found 
-WARN[0000] Could not locate libnvidia-allocator.so.575.57.08: pattern libnvidia-allocator.so.575.57.08 not found
-libnvidia-allocator.so.575.57.08: not found 
+INFO[0000] Selecting /usr/lib/x86_64-linux-gnu/libnvidia-egl-gbm.so.1.1.2 as /usr/lib/x86_64-linux-gnu/libnvidia-egl-gbm.so.1.1.2 
+INFO[0000] Selecting /usr/lib/x86_64-linux-gnu/libnvidia-egl-wayland.so.1.1.19 as /usr/lib/x86_64-linux-gnu/libnvidia-egl-wayland.so.1.1.19 
+INFO[0000] Selecting /usr/lib/x86_64-linux-gnu/libnvidia-allocator.so.575.57.08 as /usr/lib/x86_64-linux-gnu/libnvidia-allocator.so.575.57.08 
 WARN[0000] Could not locate libnvidia-vulkan-producer.so.575.57.08: pattern libnvidia-vulkan-producer.so.575.57.08 not found
 libnvidia-vulkan-producer.so.575.57.08: not found 
-WARN[0000] Could not locate nvidia_drv.so: pattern nvidia_drv.so not found 
-WARN[0000] Could not locate libglxserver_nvidia.so.575.57.08: pattern libglxserver_nvidia.so.575.57.08 not found 
-WARN[0000] Could not locate glvnd/egl_vendor.d/10_nvidia.json: pattern glvnd/egl_vendor.d/10_nvidia.json not found 
-WARN[0000] Could not locate egl/egl_external_platform.d/15_nvidia_gbm.json: pattern egl/egl_external_platform.d/15_nvidia_gbm.json not found 
-WARN[0000] Could not locate egl/egl_external_platform.d/10_nvidia_wayland.json: pattern egl/egl_external_platform.d/10_nvidia_wayland.json not found 
-WARN[0000] Could not locate nvidia/nvoptix.bin: pattern nvidia/nvoptix.bin not found 
+INFO[0000] Selecting /usr/lib64/xorg/modules/drivers/nvidia_drv.so as /usr/lib64/xorg/modules/drivers/nvidia_drv.so 
+INFO[0000] Selecting /usr/lib64/xorg/modules/extensions/libglxserver_nvidia.so.575.57.08 as /usr/lib64/xorg/modules/extensions/libglxserver_nvidia.so.575.57.08 
+INFO[0000] Selecting /usr/share/glvnd/egl_vendor.d/10_nvidia.json as /usr/share/glvnd/egl_vendor.d/10_nvidia.json 
+INFO[0000] Selecting /usr/share/egl/egl_external_platform.d/15_nvidia_gbm.json as /usr/share/egl/egl_external_platform.d/15_nvidia_gbm.json 
+INFO[0000] Selecting /usr/share/egl/egl_external_platform.d/10_nvidia_wayland.json as /usr/share/egl/egl_external_platform.d/10_nvidia_wayland.json 
+INFO[0000] Selecting /usr/share/nvidia/nvoptix.bin as /usr/share/nvidia/nvoptix.bin 
 WARN[0000] Could not locate X11/xorg.conf.d/10-nvidia.conf: pattern X11/xorg.conf.d/10-nvidia.conf not found 
 WARN[0000] Could not locate X11/xorg.conf.d/nvidia-drm-outputclass.conf: pattern X11/xorg.conf.d/nvidia-drm-outputclass.conf not found 
-WARN[0000] Could not locate vulkan/icd.d/nvidia_icd.json: pattern vulkan/icd.d/nvidia_icd.json not found
-pattern vulkan/icd.d/nvidia_icd.json not found 
+INFO[0000] Selecting /etc/vulkan/icd.d/nvidia_icd.json as /etc/vulkan/icd.d/nvidia_icd.json 
 WARN[0000] Could not locate vulkan/icd.d/nvidia_layers.json: pattern vulkan/icd.d/nvidia_layers.json not found
 pattern vulkan/icd.d/nvidia_layers.json not found 
-WARN[0000] Could not locate vulkan/implicit_layer.d/nvidia_layers.json: pattern vulkan/implicit_layer.d/nvidia_layers.json not found
-pattern vulkan/implicit_layer.d/nvidia_layers.json not found 
-INFO[0000] Selecting /usr/local/lib/libcuda.so.575.57.08 as /usr/local/lib/libcuda.so.575.57.08 
+INFO[0000] Selecting /etc/vulkan/implicit_layer.d/nvidia_layers.json as /etc/vulkan/implicit_layer.d/nvidia_layers.json 
+INFO[0000] Selecting /usr/lib/x86_64-linux-gnu/libEGL_nvidia.so.575.57.08 as /usr/lib/x86_64-linux-gnu/libEGL_nvidia.so.575.57.08 
+INFO[0000] Selecting /usr/lib/x86_64-linux-gnu/libGLESv1_CM_nvidia.so.575.57.08 as /usr/lib/x86_64-linux-gnu/libGLESv1_CM_nvidia.so.575.57.08 
+INFO[0000] Selecting /usr/lib/x86_64-linux-gnu/libGLESv2_nvidia.so.575.57.08 as /usr/lib/x86_64-linux-gnu/libGLESv2_nvidia.so.575.57.08 
+INFO[0000] Selecting /usr/lib/x86_64-linux-gnu/libGLX_nvidia.so.575.57.08 as /usr/lib/x86_64-linux-gnu/libGLX_nvidia.so.575.57.08 
+INFO[0000] Selecting /usr/lib/x86_64-linux-gnu/libcuda.so.575.57.08 as /usr/lib/x86_64-linux-gnu/libcuda.so.575.57.08 
+INFO[0000] Selecting /usr/lib/x86_64-linux-gnu/libcudadebugger.so.575.57.08 as /usr/lib/x86_64-linux-gnu/libcudadebugger.so.575.57.08 
+INFO[0000] Selecting /usr/lib/x86_64-linux-gnu/libnvcuvid.so.575.57.08 as /usr/lib/x86_64-linux-gnu/libnvcuvid.so.575.57.08 
+INFO[0000] Selecting /usr/lib/x86_64-linux-gnu/libnvidia-allocator.so.575.57.08 as /usr/lib/x86_64-linux-gnu/libnvidia-allocator.so.575.57.08 
+INFO[0000] Selecting /usr/lib/x86_64-linux-gnu/libnvidia-cfg.so.575.57.08 as /usr/lib/x86_64-linux-gnu/libnvidia-cfg.so.575.57.08 
+INFO[0000] Selecting /usr/lib/x86_64-linux-gnu/libnvidia-eglcore.so.575.57.08 as /usr/lib/x86_64-linux-gnu/libnvidia-eglcore.so.575.57.08 
+INFO[0000] Selecting /usr/lib/x86_64-linux-gnu/libnvidia-encode.so.575.57.08 as /usr/lib/x86_64-linux-gnu/libnvidia-encode.so.575.57.08 
+INFO[0000] Selecting /usr/lib/x86_64-linux-gnu/libnvidia-fbc.so.575.57.08 as /usr/lib/x86_64-linux-gnu/libnvidia-fbc.so.575.57.08 
+INFO[0000] Selecting /usr/lib/x86_64-linux-gnu/libnvidia-glcore.so.575.57.08 as /usr/lib/x86_64-linux-gnu/libnvidia-glcore.so.575.57.08 
+INFO[0000] Selecting /usr/lib/x86_64-linux-gnu/libnvidia-glsi.so.575.57.08 as /usr/lib/x86_64-linux-gnu/libnvidia-glsi.so.575.57.08 
+INFO[0000] Selecting /usr/lib/x86_64-linux-gnu/libnvidia-glvkspirv.so.575.57.08 as /usr/lib/x86_64-linux-gnu/libnvidia-glvkspirv.so.575.57.08 
+INFO[0000] Selecting /usr/lib/x86_64-linux-gnu/libnvidia-gpucomp.so.575.57.08 as /usr/lib/x86_64-linux-gnu/libnvidia-gpucomp.so.575.57.08 
+INFO[0000] Selecting /usr/lib/x86_64-linux-gnu/libnvidia-gtk2.so.575.57.08 as /usr/lib/x86_64-linux-gnu/libnvidia-gtk2.so.575.57.08 
+INFO[0000] Selecting /usr/lib/x86_64-linux-gnu/libnvidia-gtk3.so.575.57.08 as /usr/lib/x86_64-linux-gnu/libnvidia-gtk3.so.575.57.08 
+INFO[0000] Selecting /usr/lib/x86_64-linux-gnu/libnvidia-ml.so.575.57.08 as /usr/lib/x86_64-linux-gnu/libnvidia-ml.so.575.57.08 
+INFO[0000] Selecting /usr/lib/x86_64-linux-gnu/libnvidia-ngx.so.575.57.08 as /usr/lib/x86_64-linux-gnu/libnvidia-ngx.so.575.57.08 
+INFO[0000] Selecting /usr/lib/x86_64-linux-gnu/libnvidia-nvvm.so.575.57.08 as /usr/lib/x86_64-linux-gnu/libnvidia-nvvm.so.575.57.08 
+INFO[0000] Selecting /usr/lib/x86_64-linux-gnu/libnvidia-opencl.so.575.57.08 as /usr/lib/x86_64-linux-gnu/libnvidia-opencl.so.575.57.08 
+INFO[0000] Selecting /usr/lib/x86_64-linux-gnu/libnvidia-opticalflow.so.575.57.08 as /usr/lib/x86_64-linux-gnu/libnvidia-opticalflow.so.575.57.08 
+INFO[0000] Selecting /usr/lib/x86_64-linux-gnu/libnvidia-pkcs11-openssl3.so.575.57.08 as /usr/lib/x86_64-linux-gnu/libnvidia-pkcs11-openssl3.so.575.57.08 
+INFO[0000] Selecting /usr/lib/x86_64-linux-gnu/libnvidia-pkcs11.so.575.57.08 as /usr/lib/x86_64-linux-gnu/libnvidia-pkcs11.so.575.57.08 
+INFO[0000] Selecting /usr/lib/x86_64-linux-gnu/libnvidia-present.so.575.57.08 as /usr/lib/x86_64-linux-gnu/libnvidia-present.so.575.57.08 
+INFO[0000] Selecting /usr/lib/x86_64-linux-gnu/libnvidia-ptxjitcompiler.so.575.57.08 as /usr/lib/x86_64-linux-gnu/libnvidia-ptxjitcompiler.so.575.57.08 
+INFO[0000] Selecting /usr/lib/x86_64-linux-gnu/libnvidia-rtcore.so.575.57.08 as /usr/lib/x86_64-linux-gnu/libnvidia-rtcore.so.575.57.08 
+INFO[0000] Selecting /usr/lib/x86_64-linux-gnu/libnvidia-sandboxutils.so.575.57.08 as /usr/lib/x86_64-linux-gnu/libnvidia-sandboxutils.so.575.57.08 
+INFO[0000] Selecting /usr/lib/x86_64-linux-gnu/libnvidia-tls.so.575.57.08 as /usr/lib/x86_64-linux-gnu/libnvidia-tls.so.575.57.08 
+INFO[0000] Selecting /usr/lib/x86_64-linux-gnu/libnvidia-vksc-core.so.575.57.08 as /usr/lib/x86_64-linux-gnu/libnvidia-vksc-core.so.575.57.08 
+INFO[0000] Selecting /usr/lib/x86_64-linux-gnu/libnvidia-wayland-client.so.575.57.08 as /usr/lib/x86_64-linux-gnu/libnvidia-wayland-client.so.575.57.08 
+INFO[0000] Selecting /usr/lib/x86_64-linux-gnu/libnvoptix.so.575.57.08 as /usr/lib/x86_64-linux-gnu/libnvoptix.so.575.57.08 
+INFO[0000] Selecting /usr/lib/x86_64-linux-gnu/vdpau/libvdpau_nvidia.so.575.57.08 as /usr/lib/x86_64-linux-gnu/vdpau/libvdpau_nvidia.so.575.57.08 
 WARN[0000] Could not locate /nvidia-persistenced/socket: pattern /nvidia-persistenced/socket not found 
 WARN[0000] Could not locate /nvidia-fabricmanager/socket: pattern /nvidia-fabricmanager/socket not found 
 WARN[0000] Could not locate /tmp/nvidia-mps: pattern /tmp/nvidia-mps not found 
-WARN[0000] Could not locate nvidia/575.57.08/gsp*.bin: pattern nvidia/575.57.08/gsp*.bin not found 
-WARN[0000] Could not locate nvidia-smi: pattern nvidia-smi not found 
-WARN[0000] Could not locate nvidia-debugdump: pattern nvidia-debugdump not found 
-WARN[0000] Could not locate nvidia-persistenced: pattern nvidia-persistenced not found 
-WARN[0000] Could not locate nvidia-cuda-mps-control: pattern nvidia-cuda-mps-control not found 
-WARN[0000] Could not locate nvidia-cuda-mps-server: pattern nvidia-cuda-mps-server not found 
+INFO[0000] Selecting /lib/firmware/nvidia/575.57.08/gsp_ga10x.bin as /lib/firmware/nvidia/575.57.08/gsp_ga10x.bin 
+INFO[0000] Selecting /lib/firmware/nvidia/575.57.08/gsp_tu10x.bin as /lib/firmware/nvidia/575.57.08/gsp_tu10x.bin 
+INFO[0000] Selecting /usr/bin/nvidia-smi as /usr/bin/nvidia-smi 
+INFO[0000] Selecting /usr/bin/nvidia-debugdump as /usr/bin/nvidia-debugdump 
+INFO[0000] Selecting /usr/bin/nvidia-persistenced as /usr/bin/nvidia-persistenced 
+INFO[0000] Selecting /usr/bin/nvidia-cuda-mps-control as /usr/bin/nvidia-cuda-mps-control 
+INFO[0000] Selecting /usr/bin/nvidia-cuda-mps-server as /usr/bin/nvidia-cuda-mps-server 
 WARN[0000] Could not locate nvidia-imex: pattern nvidia-imex not found 
 WARN[0000] Could not locate nvidia-imex-ctl: pattern nvidia-imex-ctl not found 
-WARN[0000] Could not locate libnvidia-egl-gbm.so.*.*: pattern libnvidia-egl-gbm.so.*.* not found
-libnvidia-egl-gbm.so.*.*: not found 
-WARN[0000] Could not locate libnvidia-egl-wayland.so.*.*: pattern libnvidia-egl-wayland.so.*.* not found
-libnvidia-egl-wayland.so.*.*: not found 
-WARN[0000] Could not locate libnvidia-allocator.so.575.57.08: pattern libnvidia-allocator.so.575.57.08 not found
-libnvidia-allocator.so.575.57.08: not found 
-WARN[0000] Could not locate libnvidia-vulkan-producer.so.575.57.08: pattern libnvidia-vulkan-producer.so.575.57.08 not found
-libnvidia-vulkan-producer.so.575.57.08: not found 
-WARN[0000] Could not locate nvidia_drv.so: pattern nvidia_drv.so not found 
-WARN[0000] Could not locate libglxserver_nvidia.so.575.57.08: pattern libglxserver_nvidia.so.575.57.08 not found 
-INFO[0000] Generated CDI spec with version 0.8.0        
+INFO[0000] Generated CDI spec with version 0.8.0
 root@nvidia-container-toolkit-1-17-6-docker-28-0-0-rc-1:~# nvidia-ctk cdi list
 INFO[0000] Found 9 CDI devices                          
 nvidia.com/gpu=0
@@ -140,8 +161,8 @@ nvidia.com/gpu=GPU-2-FAKE-UUID
 nvidia.com/gpu=GPU-3-FAKE-UUID
 nvidia.com/gpu=all
 root@nvidia-container-toolkit-1-17-6-docker-28-0-0-rc-1:~# docker run -tid --runtime=nvidia -e NVIDIA_VISIBLE_DEVICES=nvidia.com/gpu=all busybox
-e44b369df15e1c7e142505cc6579247fb396cd535b57c28963ef9fa328f164a5
-root@nvidia-container-toolkit-1-17-6-docker-28-0-0-rc-1:~# cat /run/containerd/io.containerd.runtime.v2.task/moby/e44b369df15e1c7e142505cc6579247fb396cd535b57c28963ef9fa328f164a5/config.json | jq .hooks
+8771db2783a6f5bf447e2b3cea351b5948bd43fb9ed63e8c3a78757c6d911670
+root@nvidia-container-toolkit-1-17-6-docker-28-0-0-rc-1:~# cat /run/containerd/io.containerd.runtime.v2.task/moby/8771db2783a6f5bf447e2b3cea351b5948bd43fb9ed63e8c3a78757c6d911670/config.json | jq .hooks
 {
   "createContainer": [
     {
@@ -150,7 +171,22 @@ root@nvidia-container-toolkit-1-17-6-docker-28-0-0-rc-1:~# cat /run/containerd/i
         "nvidia-cdi-hook",
         "create-symlinks",
         "--link",
-        "libcuda.so.1::/usr/local/lib/libcuda.so"
+        "../libnvidia-allocator.so.1::/usr/lib/x86_64-linux-gnu/gbm/nvidia-drm_gbm.so",
+        "--link",
+        "libglxserver_nvidia.so.575.57.08::/usr/lib64/xorg/modules/extensions/libglxserver_nvidia.so"
+      ]
+    },
+    {
+      "path": "/usr/bin/nvidia-cdi-hook",
+      "args": [
+        "nvidia-cdi-hook",
+        "create-symlinks",
+        "--link",
+        "libGLX_nvidia.so.575.57.08::/usr/lib/x86_64-linux-gnu/libGLX_indirect.so.0",
+        "--link",
+        "libcuda.so.1::/usr/lib/x86_64-linux-gnu/libcuda.so",
+        "--link",
+        "libnvidia-opticalflow.so.1::/usr/lib/x86_64-linux-gnu/libnvidia-opticalflow.so"
       ]
     },
     {
@@ -167,7 +203,9 @@ root@nvidia-container-toolkit-1-17-6-docker-28-0-0-rc-1:~# cat /run/containerd/i
         "nvidia-cdi-hook",
         "update-ldcache",
         "--folder",
-        "/usr/local/lib"
+        "/usr/lib/x86_64-linux-gnu",
+        "--folder",
+        "/usr/lib/x86_64-linux-gnu/vdpau"
       ]
     }
   ]
@@ -214,19 +252,21 @@ Bus Location:   00000000:00:00.0
 Architecture:   7.5
 root@nvidia-container-toolkit-1-17-6-docker-28-0-0-rc-1:~# lsmod |grep fake
 fake_nvidia_driver     12288  0
-root@nvidia-container-toolkit-1-17-6-docker-28-0-0-rc-1:~# ls -lah /usr/local/lib/libnvidia-ml.so.1
--rwxr-xr-x 1 root root 22K Jul 25 07:38 /usr/local/lib/libnvidia-ml.so.1
-root@nvidia-container-toolkit-1-17-6-docker-28-0-0-rc-1:~# systemctl status fake-nvidia-mknod
-○ fake-nvidia-mknod.service - Create device nodes for fake nvidia driver
-     Loaded: loaded (/etc/systemd/system/fake-nvidia-mknod.service; enabled; preset: enabled)
-     Active: inactive (dead) since Fri 2025-07-25 07:46:22 UTC; 1min 40s ago
-    Process: 607 ExecStart=/usr/local/bin/fake-nvidia-mknod.sh (code=exited, status=0/SUCCESS)
-   Main PID: 607 (code=exited, status=0/SUCCESS)
-        CPU: 7ms
+root@nvidia-container-toolkit-1-17-6-docker-28-0-0-rc-1:~# ls -lah /usr/lib/x86_64-linux-gnu/libnvidia-ml.so*
+lrwxrwxrwx 1 root root  43 Jul 30 07:55 /usr/lib/x86_64-linux-gnu/libnvidia-ml.so -> /usr/lib/x86_64-linux-gnu/libnvidia-ml.so.1
+lrwxrwxrwx 1 root root  51 Jul 30 07:55 /usr/lib/x86_64-linux-gnu/libnvidia-ml.so.1 -> /usr/lib/x86_64-linux-gnu/libnvidia-ml.so.575.57.08
+-rwxr-xr-x 1 root root 22K Jul 30 07:55 /usr/lib/x86_64-linux-gnu/libnvidia-ml.so.575.57.08
+root@nvidia-container-toolkit-1-17-6-docker-28-0-0-rc-1:~# systemctl status fake-nvidia-device
+○ fake-nvidia-device.service - Create device nodes for fake nvidia driver
+     Loaded: loaded (/etc/systemd/system/fake-nvidia-device.service; enabled; preset: enabled)
+     Active: inactive (dead) since Wed 2025-07-30 08:30:00 UTC; 5min ago
+    Process: 608 ExecStart=/usr/local/bin/fake-nvidia-device.sh (code=exited, status=0/SUCCESS)
+   Main PID: 608 (code=exited, status=0/SUCCESS)
+        CPU: 8ms
 
-Jul 25 07:46:22 nvidia-container-toolkit-1-17-6-docker-28-0-0-rc-1 systemd[1]: Starting fake-nvidia-mknod.service - Create device nodes for fake nvidia driver...
-Jul 25 07:46:22 nvidia-container-toolkit-1-17-6-docker-28-0-0-rc-1 systemd[1]: fake-nvidia-mknod.service: Deactivated successfully.
-Jul 25 07:46:22 nvidia-container-toolkit-1-17-6-docker-28-0-0-rc-1 systemd[1]: Finished fake-nvidia-mknod.service - Create device nodes for fake nvidia driver.
+Jul 30 08:30:00 nvidia-container-toolkit-1-17-6-docker-28-0-0-rc-1 systemd[1]: Starting fake-nvidia-device.service - Create device nodes for fake nvidia driver...
+Jul 30 08:30:00 nvidia-container-toolkit-1-17-6-docker-28-0-0-rc-1 systemd[1]: fake-nvidia-device.service: Deactivated successfully.
+Jul 30 08:30:00 nvidia-container-toolkit-1-17-6-docker-28-0-0-rc-1 systemd[1]: Finished fake-nvidia-device.service - Create device nodes for fake nvidia driver.
 ```
 
 ### environment details
@@ -249,11 +289,11 @@ Client: Docker Engine - Community
     Path:     /usr/libexec/docker/cli-plugins/docker-compose
 
 Server:
- Containers: 0
-  Running: 0
+ Containers: 2
+  Running: 2
   Paused: 0
   Stopped: 0
- Images: 0
+ Images: 1
  Server Version: 28.0.0-rc.1
  Storage Driver: overlay2
   Backing Filesystem: extfs
@@ -269,7 +309,7 @@ Server:
   Network: bridge host ipvlan macvlan null overlay
   Log: awslogs fluentd gcplogs gelf journald json-file local splunk syslog
  Swarm: inactive
- Runtimes: io.containerd.runc.v2 nvidia runc
+ Runtimes: runc io.containerd.runc.v2 nvidia
  Default Runtime: runc
  Init Binary: docker-init
  containerd version: bcc810d6b9066471b0b6fa75f557a15a1cbf31bb
@@ -280,14 +320,14 @@ Server:
   seccomp
    Profile: builtin
   cgroupns
- Kernel Version: 6.8.0-64-generic
+ Kernel Version: 6.8.0-71-generic
  Operating System: Ubuntu 24.04.2 LTS
  OSType: linux
  Architecture: x86_64
  CPUs: 2
  Total Memory: 1.922GiB
  Name: nvidia-container-toolkit-1-17-6-docker-28-0-0-rc-1
- ID: 1ae1bcb7-332a-436e-98d8-cb256e34cca6
+ ID: 912b771a-25a3-4b3f-9432-1ce3a3f59a1c
  Docker Root Dir: /var/lib/docker
  Debug Mode: false
  Experimental: false
@@ -295,6 +335,9 @@ Server:
   ::1/128
   127.0.0.0/8
  Live Restore Enabled: false
+
+root@nvidia-container-toolkit-1-17-6-docker-28-0-0-rc-1:~# containerd --version
+containerd containerd.io 1.7.25 bcc810d6b9066471b0b6fa75f557a15a1cbf31bb
 ```
 
 ## build
@@ -306,5 +349,5 @@ make all DIR=nvidia-container-toolkit/v1.17.6_docker-v28.0.0-rc.1
 for developers:
 
 ```dockerfile
-FROM ssst0n3/docker_archive:ctr_nvidia-container-toolkit-v1.17.6_docker-v28.0.0-rc.1_v0.3.0
+FROM ssst0n3/docker_archive:ctr_nvidia-container-toolkit-v1.17.6_docker-v28.0.0-rc.1_v0.9.0
 ```

--- a/nvidia-container-toolkit/v1.17.6_docker-v28.0.0-rc.1/docker-compose.yml
+++ b/nvidia-container-toolkit/v1.17.6_docker-v28.0.0-rc.1/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   vm:
-    image: ssst0n3/docker_archive:nvidia-container-toolkit-v1.17.6_docker-v28.0.0-rc.1_v0.3.0
+    image: ssst0n3/docker_archive:nvidia-container-toolkit-v1.17.6_docker-v28.0.0-rc.1_v0.9.0
     ports:
         - "11768:22"
     tty: true


### PR DESCRIPTION
…real nvidia driver without kernel module; install i386 libs; bump fake-nvidia to v0.7.2