### PR TITLE
dqd: add v0.3.0 image with cloud-init and enhanced networking

### DIFF
--- a/dqd/v0.3.0/Dockerfile
+++ b/dqd/v0.3.0/Dockerfile
@@ -1,0 +1,8 @@
+FROM alpine:3.21
+RUN apk update && \
+    apk add --no-cache \
+        qemu-system-x86_64 \
+        cloud-utils-localds && \
+    rm -rf /var/cache/apk/*
+COPY start.sh /start.sh
+CMD [ "/start.sh" ]

--- a/dqd/v0.3.0/build.sh
+++ b/dqd/v0.3.0/build.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+docker build -t ssst0n3/docker_archive:dqd_v0.3.0 .
+docker push ssst0n3/docker_archive:dqd_v0.3.0

--- a/dqd/v0.3.0/start.sh
+++ b/dqd/v0.3.0/start.sh
@@ -1,0 +1,62 @@
+#!/bin/sh
+set -eu  # Exit on error or use of undefined variable
+
+build_default_net_args() {
+    local opts="-nic user"
+
+    # setup ip
+    [ -n "${QEMU_NET:-}" ] && opts="${opts},net=${QEMU_NET}"
+    [ -n "${QEMU_DHCPSTART:-}" ] && opts="${opts},dhcpstart=${QEMU_DHCPSTART}"
+
+    # Always enable SSH port forwarding
+    opts="${opts},hostfwd=tcp::22-:22"
+
+    # Additional port forwarding, if defined
+    [ -n "${QEMU_HOSTFWD:-}" ] && opts="${opts},${QEMU_HOSTFWD}"
+
+    echo "$opts,model=virtio"
+}
+
+# Build dual-network arguments (socket-based)
+build_dual_net_args() {
+    local opts="-nic socket"
+
+    [ -n "${QEMU_SOCKET_LISTEN:-}" ] && opts="${opts},listen=${QEMU_SOCKET_LISTEN}"
+    [ -n "${QEMU_SOCKET_CONNECT:-}" ] && opts="${opts},connect=${QEMU_SOCKET_CONNECT}"
+
+    echo "$opts,model=virtio"
+}
+
+build_cloudinit_args() {
+    cat > /user-data <<EOF
+#cloud-config
+runcmd:
+  - ip addr add ${QEMU_SOCKET_IP}/24 dev eth1
+  - ip link set eth1 up
+EOF
+    cloud-localds /seed.img /user-data
+    echo "-drive file=/seed.img,if=virtio,format=raw"
+}
+
+CMD="qemu-system-x86_64 \
+    -hda vm.qcow2 \
+    -smp 2 \
+    -m 2048M \
+    -nographic"
+
+CMD="$CMD $(build_default_net_args)"
+
+if [ -n "${QEMU_DUAL_NET:-}" ]; then
+    CMD="$CMD $(build_dual_net_args)"
+fi
+
+if [ -n "${QEMU_SOCKET_IP:-}" ]; then
+    CMD="$CMD $(build_cloudinit_args)"
+fi
+
+# setup kvm
+if [ -e /dev/kvm ]; then
+    CMD="$CMD -enable-kvm"
+fi
+
+exec $CMD "$@"

--- a/dqd/workspace/Dockerfile
+++ b/dqd/workspace/Dockerfile
@@ -1,7 +1,2 @@
-FROM ssst0n3/docker_archive:dqd_v0.2.0 AS build
+FROM ssst0n3/docker_archive:dqd_v0.3.0 AS build
 COPY vm.qcow2 /
-
-# # squash
-# FROM scratch AS release
-# COPY --from=build / /
-# CMD [ "/start.sh" ]


### PR DESCRIPTION
Add v0.3.0 Dockerfile and helper scripts.

Dockerfile:
- add cloud-utils-localds so a cloud-init seed image can be generated inside the container.

start.sh:
- enable strict shell options (set -eu).
- refactor network option construction into functions.
- default user-mode network now uses virtio model and always forwards SSH (tcp::22-:22).
- add optional dual-network (socket) support (controlled by QEMU_DUAL_NET).
- add cloud-init support using cloud-localds when QEMU_SOCKET_IP is set.
- improved env var checks and optional extra hostfwd handling.

Update:
- update `dqd/workspace/Dockerfile` to reflect compatibility changes.